### PR TITLE
Feat: OAuth2 Access Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This library is built using [Anilist official docs](https://github.com/AniList/A
 - Get genre list
 - Get tag list
 - Get user data (details, favorite, anime list, manga list)
+- Get user data with OAuth2 Access Token for private profiles
 - Search anime
 - Search manga
 - Search character
@@ -114,6 +115,21 @@ Anilist has default rate limit **90 requests per minute**. If you go over
 the rate limit you'll receive a 1-minute timeout. But, verniy has
 a built-in rate limiter to prevent the requests going over the limit.
 It will put your request on hold until the limit is available again.
+
+### OAuth2 Authentication
+
+To access private user data, you need to use OAuth2 Access Token.
+
+Read the [Anilist OAuth2 documentation](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth/getting-started) for more details.
+
+The OAuth2 Access Token can be set in the `Client` struct.
+
+```go
+c := verniy.New()
+c.AccessToken = "your-access-token"
+```
+
+This token could also be used to update user data in the future.
 
 ## Trivia
 

--- a/example/main.go
+++ b/example/main.go
@@ -38,6 +38,11 @@ func main() {
 	// d, err := c.GetUserAnimeList("rl404")
 	// d, err := c.GetUserMangaList("rl404")
 
+	// Authenticated requests for private profiles
+	// https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth/getting-started
+	// c.AccessToken = "FIXME"
+	// d, err := c.GetUserAnimeList("rl404")
+
 	// d, err := c.GetStudio(803, 1, 10)
 	// d, err := c.GetStudios(1, 10)
 	// d, err := c.GetGenres()

--- a/http.go
+++ b/http.go
@@ -111,6 +111,9 @@ func (c *Client) MakeRequest(ctx context.Context, requestBody []byte) ([]byte, i
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
+	if c.AccessToken != "" {
+		req.Header.Add("Authorization", "Bearer "+c.AccessToken)
+	}
 
 	resp, err := c.Http.Do(req)
 	if err != nil {

--- a/verniy.go
+++ b/verniy.go
@@ -9,9 +9,10 @@ import (
 
 // Client is anilist client.
 type Client struct {
-	Host    string
-	Http    http.Client
-	Limiter limiter.Limiter
+	Host        string
+	Http        http.Client
+	Limiter     limiter.Limiter
+	AccessToken string
 }
 
 // New to create new anilist client.


### PR DESCRIPTION
The client can now handle access token to make authenticated requests to AniList API.

For now, it is only useful for getting private profile data. In the future it could be used to make updates to AniList with the API but I don't intend to work on that for now.

I've given a lot of thought to including functions to retrieve the access token or authentication PIN, but I think it's beyond the scope of this library.