### PR TITLE
refactor(utils): reduce FieldObject complexity

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -6,56 +6,68 @@ import (
 	"strings"
 )
 
+// formatParamValue formats a single parameter value for the query string.
+// It returns the formatted string and a boolean indicating if the value should be included.
+func formatParamValue(p interface{}) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	v := reflect.ValueOf(p)
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		if v.Len() == 0 {
+			return "", false
+		}
+		vArr := make([]string, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			vArr[i] = fmt.Sprintf("%v", v.Index(i))
+		}
+		return fmt.Sprintf("[%v]", strings.Join(vArr, ",")), true
+	case reflect.String:
+		if v.Len() == 0 {
+			return "", false
+		}
+		return fmt.Sprintf("%v", p), true
+	case reflect.Int:
+		if v.Int() == 0 {
+			return "", false
+		}
+		return fmt.Sprintf("%v", p), true
+	case reflect.Ptr:
+		if v.IsNil() {
+			return "", false
+		}
+		return fmt.Sprintf("%v", v.Elem()), true
+	default:
+		return fmt.Sprintf("%v", p), true
+	}
+}
+
 // FieldObject to generate query string.
 //
 // Example:
 //
-//   FieldObject("key", map[string]interface{}{
-// 	  "name1": "value1",
-// 	  "name2": []string{"value2", "value3"},
-//   }, "field1", "field2")
+//	  FieldObject("key", map[string]interface{}{
+//		  "name1": "value1",
+//		  "name2": []string{"value2", "value3"},
+//	  }, "field1", "field2")
 //
 // Will generate:
 //
-//   key(name1:value1, name2:[value2,value3]) {
-//     field1
-//     field2
-//   }
+//	key(name1:value1, name2:[value2,value3]) {
+//	  field1
+//	  field2
+//	}
 //
 // Or just see usage example in some functions in verniy package.
 func FieldObject(key string, params map[string]interface{}, fields ...string) string {
 	var paramStr string
-	if params != nil || len(params) > 0 {
+	if len(params) > 0 {
 		var paramArr []string
 		for k, p := range params {
-			if p == nil {
-				continue
-			}
-
-			switch reflect.TypeOf(p).Kind() {
-			case reflect.Slice, reflect.Array:
-				v := reflect.ValueOf(p)
-				if v.Len() > 0 {
-					vArr := make([]string, v.Len())
-					for i := 0; i < v.Len(); i++ {
-						vArr[i] = fmt.Sprintf("%v", v.Index(i))
-					}
-					paramArr = append(paramArr, fmt.Sprintf("%v:[%v]", k, strings.Join(vArr, ",")))
-				}
-			case reflect.String:
-				if reflect.ValueOf(p).Len() != 0 {
-					paramArr = append(paramArr, fmt.Sprintf("%v:%v", k, p))
-				}
-			case reflect.Int:
-				if reflect.ValueOf(p).Int() != 0 {
-					paramArr = append(paramArr, fmt.Sprintf("%v:%v", k, p))
-				}
-			case reflect.Ptr:
-				if !reflect.ValueOf(p).IsNil() {
-					paramArr = append(paramArr, fmt.Sprintf("%v:%v", k, reflect.ValueOf(p).Elem()))
-				}
-			default:
-				paramArr = append(paramArr, fmt.Sprintf("%v:%v", k, p))
+			formattedVal, ok := formatParamValue(p)
+			if ok {
+				paramArr = append(paramArr, fmt.Sprintf("%v:%v", k, formattedVal))
 			}
 		}
 		if len(paramArr) > 0 {


### PR DESCRIPTION
Extract parameter formatting logic from FieldObject into a new helper function formatParamValue.

This addresses a gocyclo warning by reducing the cyclomatic complexity of FieldObject from 17 to below the recommended threshold of 15.